### PR TITLE
Allow local changes of Procfile.dev

### DIFF
--- a/.foreman.sample
+++ b/.foreman.sample
@@ -1,0 +1,2 @@
+procfile: Procfile.dev
+port: 5000

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ doc/controllers_complete.svg
 doc/models_brief.svg
 doc/models_complete.svg
 .zsh_rake_cache
+
+.foreman
+Procfile.dev

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,0 @@
-web: bundle exec rails server -p $PORT


### PR DESCRIPTION
This allows individual developers to configure their local foreman setup
as they see fit. You can run postgres, or redid, or sidekiq, or any
other service required, without needing to affect the deployment to
real environments.
